### PR TITLE
typo fix in buildroot makfile for bluez_utils

### DIFF
--- a/package/thirdparty/bluez_utils/bluez_utils.mk
+++ b/package/thirdparty/bluez_utils/bluez_utils.mk
@@ -45,4 +45,4 @@ BLUEZ_UTILS_CONF_OPT +=	\
 	--disable-usb
 endif
 
-$(eval $(call AUTOTARGETS,package/bluez_utils,bluez_utils))
+$(eval $(call AUTOTARGETS,package/thirdparty,bluez_utils))


### PR DESCRIPTION
without this, patches to the plugins subdir fails
now consistent with all other package/thirdparty/*.mk files
