### PR TITLE
Fixes amremote_config installation if target dir does not exist.

### DIFF
--- a/package/amlogic/amremote_config/amremote_config.mk
+++ b/package/amlogic/amremote_config/amremote_config.mk
@@ -13,8 +13,9 @@ define AMREMOTE_CONFIG_BUILD_CMDS
 endef
 
 define AMREMOTE_CONFIG_INSTALL_TARGET_CMDS
-        install -m 755 $(@D)/keytest $(TARGET_DIR)/usr/bin
-        install -m 755 $(@D)/amremote_config $(TARGET_DIR)/usr/bin
+        install -d $(TARGET_DIR)/usr/bin
+        install -m 755 -t $(TARGET_DIR)/usr/bin $(@D)/keytest
+        install -m 755 -t $(TARGET_DIR)/usr/bin $(@D)/amremote_config
 endef
 
 $(eval $(call GENTARGETS,package/amlogic,amremote_config))


### PR DESCRIPTION
In my custom builds I remove build gdb debugger and server for target. This has the side affect of the $(TARGET_DIR)/usr/bin not existing yet during the installation step of the amremote_config.  This caused keytest to be lost and amremote_config command to be moved as a normal file of the name bin to $(TARGET_DIR)/usr.

This change fixes the installation step to use install to create $(TARGET_DIR)/usr/bin.  In addition, I changed the other install commands to explicitly use the install -t form which would error out, instead of making a normal file called bin.
