### PR TITLE
Logs to usb

### DIFF
--- a/package/usbmount/diag.sh
+++ b/package/usbmount/diag.sh
@@ -4,7 +4,7 @@ if [ "$ACTION" == "add" ] ; then
   # get device name from udev variable
   DRIVE=$DEVNAME
   # check mounted drive for this drive
-  MOUNTSTRING=`fgrep $DRIVE /proc/mounts`
+  MOUNTSTRING=`fgrep "$DRIVE " /proc/mounts`
   MOUNTDEV=`echo $MOUNTSTRING | awk '{print $1}'`
   MOUNTPOINT=`echo $MOUNTSTRING | awk '{print $2}'`
   OUTDIR="$MOUNTPOINT/getlogs"

--- a/package/usbmount/diag.sh
+++ b/package/usbmount/diag.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# if ACTION from udev is add then 
+if [ "$ACTION" == "add" ] ; then
+  # get device name from udev variable
+  DRIVE=$DEVNAME
+  # check mounted drive for this drive
+  MOUNTSTRING=`fgrep $DRIVE /proc/mounts`
+  MOUNTDEV=`echo $MOUNTSTRING | awk '{print $1}'`
+  MOUNTPOINT=`echo $MOUNTSTRING | awk '{print $2}'`
+  OUTDIR="$MOUNTPOINT/getlogs"
+  OUTFILE="$OUTDIR/diag.txt"
+  # check if drive is mounted
+  if [ "$MOUNTDEV" == "$DRIVE" ]; then
+    # check if output directory exists
+    if [ -d "$OUTDIR" ]; then
+       # copy xbmc logfiles to $OUTDIR
+       cp /root/.xbmc/temp/xbmc*.log $OUTDIR
+       # redirect stdout/stderror to $OUTFILE
+       exec 1>$OUTFILE 2>&1
+       # if runme exists in directory then run it
+       # output results to $OUTDIR/runme.txt
+       if [ -f "$OUTDIR/runme.sh" ]; then
+          sh $OUTDIR/runme.sh $OUTDIR 1>$OUTDIR/runme.txt 2>&1
+       fi
+	
+    else
+       exit
+     fi
+  fi
+fi
+# run some diagnostics
+echo free:-----------------
+free
+echo
+echo iwconfig:-------------
+iwconfig
+echo
+echo ifconfig:-------------
+ifconfig
+echo
+echo df:-------------------
+df
+echo
+echo ping:-----------------
+ping -c 1 www.google.com
+echo
+echo lsmod:----------------
+lsmod
+echo
+

--- a/package/usbmount/usbmount-rules-fix.patch
+++ b/package/usbmount/usbmount-rules-fix.patch
@@ -2,7 +2,7 @@ Index: b/usbmount.rules
 ===================================================================
 --- a/usbmount.rules
 +++ b/usbmount.rules
-@@ -1,7 +1,9 @@
+@@ -1,7 +1,12 @@
  # Rules for USBmount -*- conf -*-
 
  KERNEL=="sd*", DRIVERS=="sbp2",		ACTION=="add",	RUN+="/usr/share/usbmount/usbmount add"
@@ -11,6 +11,9 @@ Index: b/usbmount.rules
 +KERNEL=="sd*", SUBSYSTEM=="block",	ACTION=="add",	RUN+="/usr/share/usbmount/usbmount add"
 +KERNEL=="ub*", SUBSYSTEM=="block",	ACTION=="add",	RUN+="/usr/share/usbmount/usbmount add"
 +KERNEL=="cardblk*", SUBSYSTEM=="block", ACTION=="add",  RUN+="/usr/share/usbmount/usbmount add"
++KERNEL=="sd*", SUBSYSTEM=="block",     ACTION=="add",  RUN+="/usr/bin/diag.sh"
++KERNEL=="ub*", SUBSYSTEM=="block",     ACTION=="add",  RUN+="/usr/bin/diag.sh"
++KERNEL=="cardblk*", SUBSYSTEM=="block", ACTION=="add",  RUN+="/usr/bin/diag.sh"
  KERNEL=="sd*",				ACTION=="remove",	RUN+="/usr/share/usbmount/usbmount remove"
  KERNEL=="ub*",				ACTION=="remove",	RUN+="/usr/share/usbmount/usbmount remove"
 +KERNEL=="cardblk*",			ACTION=="remove",	RUN+="/usr/share/usbmount/usbmount remove"

--- a/package/usbmount/usbmount.mk
+++ b/package/usbmount/usbmount.mk
@@ -15,6 +15,7 @@ define USBMOUNT_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/etc/usbmount/usbmount.d/00_create_model_symlink
 	$(INSTALL) -m 0755 -D $(@D)/00_remove_model_symlink 	\
 		$(TARGET_DIR)/etc/usbmount/usbmount.d/00_remove_model_symlink
+	$(INSTALL) -m 0755 -D package/usbmount/diag.sh $(TARGET_DIR)/usr/bin
 
 	$(INSTALL) -m 0644 -D $(@D)/usbmount.rules $(TARGET_DIR)/lib/udev/rules.d/usbmount.rules
 	@if [ ! -f $(TARGET_DIR)/etc/usbmount/usbmount.conf ]; then \


### PR DESCRIPTION
Copy logs and diagnostic info to USB storage automatically on device insert

This is a simple mod to usbmount rules to gather debug information for cases where you can't SSH into the box.

When device can't connect to a network it can be difficult to troubleshoot issue as you can't retrieve logs from the system.   This simple patch is designed to leverage a usb flash drive and the usbmount process to run diagnostics under certain conditions when a usb flash drive is plugged it and output the results to the flash drive.

After this patch, take a usb flash drive and create a directory on it called getlogs in the root directory:
  mkdr /getlogs
Then plug the usb drive into system and if the getlogs directory exists the diag.sh script will run and put its contents in /getlogs/diag.txt and the script will also copy the xbmc log files to the getlogs directory as well.

The modification also looks for a shell script in /getlogs/runme.sh
Which allows additional commands to be run after USB device is inserted.   The mountpoint directory is passed as an argument to the runme.sh scripts as first argument.
Can be used for things like updating firmware or gathering additional diagnostic information.
