### PR TITLE
Modified S10setup to move userdata to sdcard on boot if /xbmc-data direc...

### DIFF
--- a/board/amlogic/xios/skeleton/etc/init.d/S10setup
+++ b/board/amlogic/xios/skeleton/etc/init.d/S10setup
@@ -1,5 +1,6 @@
 #!/bin/sh
-
+exec 1>/tmp/init.log
+exec 2>>/tmp/init.log
 if [ "X$1" = "Xstart" ]; then
   echo "S10setup: init fb0, fb1"
   # blank the fb's
@@ -17,6 +18,93 @@ if [ "X$1" = "Xstart" ]; then
   #
   echo "S10setup: remount / rw"
   mount -o remount,rw /
+
+  echo "S10setup: moving /media"
+  # /media is where usb drives mount, move it to /tmp and bind
+  if [ ! -d /tmp/media ]; then
+    mkdir -p /tmp/media
+    cp -a /media /tmp/
+    mount -o bind /tmp/media /media
+  fi
+  #
+  echo "S10setup: moving /etc"
+  # /etc must be rw, move it to /tmp and bind
+  mkdir -p /tmp/etc
+  cp -a /etc /tmp/
+  mount -o bind /tmp/etc /etc
+  #
+
+  # Check if sdcard mount point exists
+  echo "S10setup: Setting up Sdcard"
+  if [ ! -d /media/sdcard ] ; then
+    mkdir -p /media/sdcard
+  fi
+  # Check if sdcard mounted, if not try to mount it
+  if ! grep -qs '/media/sdcard/' /proc/mounts; then
+   if [ -e "/dev/cardblksd1" ]; then
+     echo "S10setup: SDCard /dev/cardblksd1 mounted as /media/sdcard"
+     /bin/mount -o rw,sync,noatime /dev/cardblksd1 /media/sdcard
+     echo "/dev/cardblksd1	/media/sdcard	vfat	rw,sync	0	0" >> /etc/fstab
+   elif [ -e "/dev/cardblksd" ]; then
+     echo "S10setup: SDCard /dev/cardblksd mounted as /media/sdcard"
+     /bin/mount -o rw,sync,noatime /dev/cardblksd /media/sdcard
+     echo "/dev/cardblksd	/media/sdcard	vfat	rw,sync	0	0" >> /etc/fstab
+   else
+    echo "S10setup:  No SDCard found"
+   fi
+  fi
+  # Test if SDCard is mounted
+  if grep -qs '/media/sdcard' /proc/mounts; then
+     # Check if we should keep running S94xbmc-pre mount scripts
+       SDCARD_MOUNTED=1
+  else
+     SDCARD_MOUNTED=0
+  fi
+
+  echo "S10setup: mounting /tmp/userdata"
+  # find userdata via mtd partition name
+  for i in `ls /dev/mtd* | grep -o "mtd[0-9]$"`; do
+    if [[ "`cat /sys/devices/virtual/mtd/$i/name`" == "userdata" ]]; then
+      USERDATA="/dev/"`ls /sys/devices/virtual/mtd/$i | grep -o mtdblock[0-9]`
+      break
+    fi
+  done
+
+  # Make /tmp/userdata mount point
+  mkdir -p /tmp/userdata
+
+  echo "S10Setup: checking for xbmc-data"
+  # Check if we have xbmc-data exists on sdcard
+  if [[ $SDCARD_MOUNTED && -d "/media/sdcard/xbmc-data" ]]; then
+       SDCARD_XBMC_DATA=1
+  else 
+       SDCARD_XBMC_DATA=0
+  fi
+
+  # Check if user-data on sdcard
+  if [[ $SDCARD_MOUNTED && -d "/media/sdcard/xbmc-data/userdata" ]]; then
+       SDCARD_USERDATA=1
+  else 
+       SDCARD_USERDATA=0
+  fi
+  
+  # if xbmc-data exists on sdcard
+  # but userdata doesn't exist, then copy data to sdcard
+  echo "S10Setup: Checking if should copy userdata"
+  if [[ $SDCARD_XBMC_DATA -eq 1 && $SDCARD_USERDATA -eq 0 ]]; then
+      # Temporarily mount userdata
+      mount -t yaffs2 $USERDATA /tmp/userdata
+      echo "S10Setup: Copying userdata"
+      cp -rp /tmp/userdata /media/sdcard/xbmc-data/userdata
+      if [ $? -neq 0 ] ; then
+        echo "S10setup: Copying Error"
+      else  
+        echo "S10setup: Data Copied to card"
+        SDCARD_USERDATA=1
+      fi
+      umount /tmp/userdata 
+  fi
+
   #
   echo "S10setup: checking keys"
   # Make sure dropbear directory exists
@@ -34,31 +122,35 @@ if [ "X$1" = "Xstart" ]; then
     /usr/bin/dropbearkey -t dss -f /etc/dropbear/dropbear_dss_host_key > /dev/null 2>&1
   fi
   #
-  echo "S10setup: moving /etc"
-  # /etc must be rw, move it to /tmp and bind
-  mkdir -p /tmp/etc
-  cp -a /etc /tmp/
-  mount -o bind /tmp/etc /etc
-  #
-  echo "S10setup: moving /media"
-  # /media is where usb drives mount, move it to /tmp and bind
-  mkdir -p /tmp/media
-  cp -a /media /tmp/
-  mount -o bind /tmp/media /media
-  #
-  echo "S10setup: mounting /tmp/userdata"
-  # find userdata via mtd partition name, mount it and bind to /root
-  for i in `ls /dev/mtd* | grep -o "mtd[0-9]$"`; do
-    if [[ "`cat /sys/devices/virtual/mtd/$i/name`" == "userdata" ]]; then
-      USERDATA="/dev/"`ls /sys/devices/virtual/mtd/$i | grep -o mtdblock[0-9]`
-      break
-    fi
-  done
 
-  mkdir -p /tmp/userdata
-  mount -t yaffs2 $USERDATA /tmp/userdata
-  mkdir -p /tmp/userdata/xios/root
+  if [ $SDCARD_USERDATA -eq 1 ]; then
+    echo "S10setup: Found userdata on sdcard, mounting"
+    mount -o bind /media/sdcard/xbmc-data/userdata /tmp/userdata
+    mkdir -p /tmp/userdata.internal
+    mount -t yaffs2 $USERDATA /tmp/userdata.internal
+    # fix tmp directory, needs to be on ext for sockets
+    if [ ! -d "/tmp/userdata.internal/xios/root/.xbmc/temp" ]; then
+      mkdir -p /tmp/userdata.internal/xios/root/.xbmc/temp
+    fi
+    if [ ! -d "/tmp/userdata/xios/root/.xbmc/temp" ]; then
+      mkdir -p /tmp/userdata/xios/root/.xbmc/temp
+    fi
+    # bind tmp on mtd to temp on sdcard to accout for sockets on fs
+    mount -o bind /tmp/userdata.internal/xios/root/.xbmc/temp /tmp/userdata/xios/root/.xbmc/temp
+  else
+    echo "S10setup: mounting userdata from mtd"
+    mount -t yaffs2 $USERDATA /tmp/userdata
+  fi
+  # if root dir doesn't exist then make it
+  if [ ! -d "/tmp/userdata/xios/root" ]; then
+    mkdir -p /tmp/userdata/xios/root
+  fi
+  # setup root dir
   mount -o bind /tmp/userdata/xios/root /root
+
+  if [ $SDCARD_USERDATA -eq 1 ]; then
+    mount -o bind /tmp/userdata.internal/xios/root/.xbmc/temp /root/.xbmc/temp
+  fi
   #
   echo "S10setup: remount / ro"
   mount -o remount,ro /
@@ -69,5 +161,15 @@ if [ "X$1" = "Xstart" ]; then
   echo "ondemand" > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
   echo "600000"   > /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
   #
+
+  # Safety section, rename S94xbmc-pre if it was designed to move userdata
+  if [ $SDCARD_USERDATA -eq 1 ]; then
+    if grep -qs 'mount -o bind /media/sdcard' /tmp/userdata/xios/root/.xbmc/S94xbmc-pre; then
+     # Found S94xbmc script that manipulates userdata so rename it
+     echo "S10setup:  Found dangerous S94xbmc-pre, renaming it"
+     mv  /tmp/userdata/xios/root/.xbmc/S94xbmc-pre /tmp/userdata/xios/root/.xbmc/S94xbmc-pre.disabled
+    fi
+  fi
   echo "S10setup: done"
 fi
+

--- a/board/amlogic/xios/skeleton/etc/init.d/S10setup
+++ b/board/amlogic/xios/skeleton/etc/init.d/S10setup
@@ -113,6 +113,9 @@ if [ "X$1" = "Xstart" ]; then
   if [[ $SDCARD_XBMC_DATA -eq 1 && $SDCARD_USERDATA -eq 0 ]]; then
       # Temporarily mount userdata
       mount -t yaffs2 $USERDATA /tmp/userdata
+      if [ -f /usr/share/splash/copying.fb.lzo ]; then
+         lzopcat /usr/share/splash/copying.fb.lzo > /dev/fb0
+      fi
       echo "S10Setup: Copying userdata"
       # turn cache back on speed this up
       mount -o remount,async /media/sdcard

--- a/board/amlogic/xios/skeleton/etc/init.d/S10setup
+++ b/board/amlogic/xios/skeleton/etc/init.d/S10setup
@@ -114,6 +114,8 @@ if [ "X$1" = "Xstart" ]; then
       # Temporarily mount userdata
       mount -t yaffs2 $USERDATA /tmp/userdata
       echo "S10Setup: Copying userdata"
+      # turn cache back on speed this up
+      mount -o remount,async /media/sdcard
       cp -rp /tmp/userdata $XBMC_USERDATA_PATH
       if [ $? -neq 0 ] ; then
         echo "S10setup: Copying Error"
@@ -121,6 +123,9 @@ if [ "X$1" = "Xstart" ]; then
         echo "S10setup: Data Copied to card"
         SDCARD_USERDATA=1
       fi
+      sync
+      # turn cache back off for safety
+      mount -o remount,sync /media/sdcard
       umount /tmp/userdata 
   fi
 

--- a/board/amlogic/xios/skeleton/etc/init.d/S10setup
+++ b/board/amlogic/xios/skeleton/etc/init.d/S10setup
@@ -1,6 +1,13 @@
 #!/bin/sh
 exec 1>/tmp/init.log
 exec 2>>/tmp/init.log
+#  Variables 
+#    SDCARD_MOUNTED  	 1 = sdcard mounted, 0  = failed
+#    SDCARD_XBMC_DATA 	 1 = found /medis/sdacard/xbmc-data, 0 = doesn't exist
+#    SDCARD_USERDATA     1 if  XBMC_USERDATA_PATH directory exists, 0 if it doesn't
+#    XBMC_DATA_PATH      if SDCARD_XBMC_DATA ==1, then contains path to xbmc-data folder on sdcard
+#    XBMC_USERDATA_PATH  if SDCARD_XMBC_DATA ==1, contains location of userdata folder on sdcard
+#
 if [ "X$1" = "Xstart" ]; then
   echo "S10setup: init fb0, fb1"
   # blank the fb's
@@ -26,6 +33,7 @@ if [ "X$1" = "Xstart" ]; then
     cp -a /media /tmp/
     mount -o bind /tmp/media /media
   fi
+
   #
   echo "S10setup: moving /etc"
   # /etc must be rw, move it to /tmp and bind
@@ -53,12 +61,13 @@ if [ "X$1" = "Xstart" ]; then
     echo "S10setup:  No SDCard found"
    fi
   fi
+
   # Test if SDCard is mounted
   if grep -qs '/media/sdcard' /proc/mounts; then
      # Check if we should keep running S94xbmc-pre mount scripts
-       SDCARD_MOUNTED=1
+        SDCARD_MOUNTED=1
   else
-     SDCARD_MOUNTED=0
+	SDCARD_MOUNTED=0
   fi
 
   echo "S10setup: mounting /tmp/userdata"
@@ -74,15 +83,25 @@ if [ "X$1" = "Xstart" ]; then
   mkdir -p /tmp/userdata
 
   echo "S10Setup: checking for xbmc-data"
-  # Check if we have xbmc-data exists on sdcard
-  if [[ $SDCARD_MOUNTED && -d "/media/sdcard/xbmc-data" ]]; then
-       SDCARD_XBMC_DATA=1
-  else 
-       SDCARD_XBMC_DATA=0
-  fi
+  # Check if xbmc-data exists on sdcard
+  # this is an horrible way to this, but only way to do case insensitve match in this shell
+	if [ $SDCARD_MOUNTED -eq 1 ]; then
+         # do directory list to see if it exists
+	 XBMC_DATA_PATH="`ls -dp /media/sdcard/* | fgrep -i "/media/sdcard/xbmc-data/"`"
+         # if not equal zero then set userdata path variable
+	 if [[ ! -z $XBMC_DATA_PATH ]]; then
+	   SDCARD_XBMC_DATA=1
+	   XBMC_USERDATA_PATH=$XBMC_DATA_PATH"userdata"
+	 else
+	   SDCARD_XBMC_DATA=0
+	 fi
+	else
+	 SDCARD_XBMC_DATA=0
+	fi
 
   # Check if user-data on sdcard
-  if [[ $SDCARD_MOUNTED && -d "/media/sdcard/xbmc-data/userdata" ]]; then
+  if [[ $SDCARD_XBMC_DATA -eq 1 && -d $XBMC_USERDATA_PATH ]]; then
+       echo "S10Setup: Found userdata directory on sdcard"
        SDCARD_USERDATA=1
   else 
        SDCARD_USERDATA=0
@@ -95,7 +114,7 @@ if [ "X$1" = "Xstart" ]; then
       # Temporarily mount userdata
       mount -t yaffs2 $USERDATA /tmp/userdata
       echo "S10Setup: Copying userdata"
-      cp -rp /tmp/userdata /media/sdcard/xbmc-data/userdata
+      cp -rp /tmp/userdata $XBMC_USERDATA_PATH
       if [ $? -neq 0 ] ; then
         echo "S10setup: Copying Error"
       else  
@@ -125,7 +144,7 @@ if [ "X$1" = "Xstart" ]; then
 
   if [ $SDCARD_USERDATA -eq 1 ]; then
     echo "S10setup: Found userdata on sdcard, mounting"
-    mount -o bind /media/sdcard/xbmc-data/userdata /tmp/userdata
+    mount -o bind $XBMC_USERDATA_PATH /tmp/userdata
     mkdir -p /tmp/userdata.internal
     mount -t yaffs2 $USERDATA /tmp/userdata.internal
     # fix tmp directory, needs to be on ext for sockets

--- a/package/dropbear/S50dropbear
+++ b/package/dropbear/S50dropbear
@@ -9,28 +9,28 @@
 start() {
  	echo -n "Starting dropbear sshd: "
 	# Make sure dropbear directory exists
-	if [ ! -d /etc/dropbear ] ; then
-		mkdir -p /etc/dropbear
+	if [ ! -d /tmp/userdata/etc/dropbear ] ; then
+		mkdir -p /tmp/userdata/etc/dropbear
 	fi
 	# Check for the Dropbear RSA key
-	if [ ! -f /etc/dropbear/dropbear_rsa_host_key ] ; then
+	if [ ! -f /tmp/userdata/etc/dropbear/dropbear_rsa_host_key ] ; then
 		echo -n "generating rsa key... "
-		/usr/bin/dropbearkey -t rsa -f /etc/dropbear/dropbear_rsa_host_key > /dev/null 2>&1
+		/usr/bin/dropbearkey -t rsa -f /tmp/userdata/etc/dropbear/dropbear_rsa_host_key > /dev/null 2>&1
 	fi
 
 	# Check for the Dropbear DSS key
-	if [ ! -f /etc/dropbear/dropbear_dss_host_key ] ; then
+	if [ ! -f /tmp/userdata/etc/dropbear/dropbear_dss_host_key ] ; then
 		echo -n "generating dsa key... "
-		/usr/bin/dropbearkey -t dss -f /etc/dropbear/dropbear_dss_host_key > /dev/null 2>&1
+		/usr/bin/dropbearkey -t dss -f /tmp/userdata/etc/dropbear/dropbear_dss_host_key > /dev/null 2>&1
 	fi
 
         # If one or more keys exist on SDCard, use that instead
 	 HOSTKEYS=""
-        if [ -f /media/sdcard/xbmc-data/etc/dropbear/dropbear_dss_host_key ]; then
-	 HOSTKEYS=" -d /media/sdcard/xbmc-data/etc/dropbear/dropbear_dss_host_key"
+        if [ -f /tmp/userdata/etc/dropbear/dropbear_dss_host_key ]; then
+	 HOSTKEYS=" -d /tmp/userdata/etc/dropbear/dropbear_dss_host_key"
 	fi
-        if [ -f /media/sdcard/xbmc-data/etc/dropbear/dropbear_rsa_host_key ]; then
-         HOSTKEYS="$HOSTKEYS -r /media/sdcard/xbmc-data/etc/dropbear/dropbear_rsa_host_key"
+        if [ -f /tmp/userdata/etc/dropbear/dropbear_rsa_host_key ]; then
+         HOSTKEYS="$HOSTKEYS -r /tmp/userdata/etc/dropbear/dropbear_rsa_host_key"
         fi
 	
 	umask 077

--- a/package/dropbear/S50dropbear
+++ b/package/dropbear/S50dropbear
@@ -23,8 +23,18 @@ start() {
 		echo -n "generating dsa key... "
 		/usr/bin/dropbearkey -t dss -f /etc/dropbear/dropbear_dss_host_key > /dev/null 2>&1
 	fi
+
+        # If one or more keys exist on SDCard, use that instead
+	 HOSTKEYS=""
+        if [ -f /media/sdcard/xbmc-data/etc/dropbear/dropbear_dss_host_key ]; then
+	 HOSTKEYS=" -d /media/sdcard/xbmc-data/etc/dropbear/dropbear_dss_host_key"
+	fi
+        if [ -f /media/sdcard/xbmc-data/etc/dropbear/dropbear_rsa_host_key ]; then
+         HOSTKEYS="$HOSTKEYS -r /media/sdcard/xbmc-data/etc/dropbear/dropbear_rsa_host_key"
+        fi
+	
 	umask 077
-	start-stop-daemon -S -q -p /var/run/dropbear.pid --exec /usr/sbin/dropbear
+	start-stop-daemon -S -q -p /var/run/dropbear.pid --exec /usr/sbin/dropbear -- $HOSTKEYS
 	echo "OK"
 }
 stop() {


### PR DESCRIPTION
...tory exists on sdcard

Mount mSD card as sync, slightly slower write speeds in favor of data integrity.
first partition of sdcard mounted as /mnt/sdcard
Copies all of /tmp/userdata to /mnt/sdcard/xbmc-data/userdata if /xbmc-data directory exists on sdcard
Then bind mounts userdata from sdcard over locations on filesystem to xbmc uses sdcard instead of internal storage.

also........
-Dropbear
Modify S50dropbear to get keys from sdcard if they exist.
With this modification, if you copy your ssh keys from /etc to /media/sdcard/xbmc-data/etc dropbear will use those on boot.
Nice little benefit of not having to clear your cached keys every time you upgrade firmware.
