### PR TITLE
Capture standard out and standard error for xbmc

### DIFF
--- a/package/thirdparty/xbmc/etc/init.d/S95xbmc
+++ b/package/thirdparty/xbmc/etc/init.d/S95xbmc
@@ -5,6 +5,13 @@
 
 case "$1" in
   start)
+        # setup logging
+        if [ -f /root/.xbmc/temp/xbmcstart.log ]; then
+            mv /root/.xbmc/temp/xbmcstart.log /root/.xbmc/temp/xbmcstart.old.log
+        fi
+        exec 1>/root/.xbmc/temp/xbmcstart.log
+        exec 2>&1
+
         echo "Starting XBMC..."
         export LD_LIBRARY_PATH=/usr/lib/mysql:$LD_LIBRARY_PATH
         export XBMC_HOME=/usr/share/xbmc


### PR DESCRIPTION
This way we log exceptions when xbmc restarts, so we actually have a clue what assertion or exception was thrown.   Makes it much easier to find reason for segfaults because can actually see log for the segfault.

logged to /root/.xbmc/temp/xbmcstart.log  and xbmcstart.old.log
