### PR TITLE
Feature: Add upstream feature to configure/adjust PVR buffers

### DIFF
--- a/package/thirdparty/xbmc/advancedsettings.xml
+++ b/package/thirdparty/xbmc/advancedsettings.xml
@@ -2,6 +2,11 @@
   <enablenetworkmanager>1</enablenetworkmanager>
   <showexitbutton>false</showexitbutton>
 
+  <pvr>
+    <minvideocachelevel>50</minvideocachelevel>
+    <minaudiocachelevel>50</minaudiocachelevel>
+  </pvr>
+
   <hidesettings>
     <setting>lookandfeel.soundskin</setting>
     <setting>videoplayer.rendermethod</setting>
@@ -21,5 +26,4 @@
     <setting>input.remoteaskeyboard</setting>
     <setting>audiooutput.guisoundmode</setting>
   </hidesettings>
-
 </advancedsettings>


### PR DESCRIPTION
Hi,

with this feature mentioned by opdenkamp...
http://forum.xbmc.org/showthread.php?tid=113083&pid=919735#pid919735
...we're able to tune the PVR buffers a little bit.

Init values of both variables would be 10%.

Regards JK
